### PR TITLE
fix: corrige shell injection no step de checagem do CodeQL

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,27 +51,28 @@ jobs:
       - name: Checar alertas do CodeQL via API
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          # github.ref em PRs retorna refs/pull/N/merge — a API precisa de refs/heads/<branch>
-          # github.head_ref tem o branch de origem do PR; github.ref_name funciona em pushes diretos
-          BRANCH_REF="refs/heads/${{ github.head_ref || github.ref_name }}"
+          BRANCH_REF="refs/heads/${HEAD_REF:-$REF_NAME}"
           echo "🔍 Consultando alertas de code scanning para o branch: $BRANCH_REF"
- 
+
           ALERTS=$(curl -s \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?tool_name=CodeQL&state=open&ref=$BRANCH_REF&per_page=100")
- 
+            "https://api.github.com/repos/${REPOSITORY}/code-scanning/alerts?tool_name=CodeQL&state=open&ref=${BRANCH_REF}&per_page=100")
+
           COUNT=$(echo "$ALERTS" | jq '[.[] | select(.rule.severity == "high" or .rule.severity == "critical")] | length')
- 
+
           echo "⚠️ Alertas High/Critical encontrados: $COUNT"
- 
+
           if [ "$COUNT" -gt "0" ]; then
             echo "❌ CodeQL encontrou $COUNT vulnerabilidade(s) de severidade High ou Critical"
             echo "$ALERTS" | jq '.[].rule.description'
             exit 1
           fi
- 
+
           echo "✅ Nenhuma vulnerabilidade High/Critical encontrada pelo CodeQL"
 
   # =========================================

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,8 +45,8 @@ jobs:
  
       - name: Rodar CodeQL
         uses: github/codeql-action/analyze@v4
-          with:
-            output: codeql-results 
+        with:
+          output: codeql-results 
  
       - name: Checar alertas do CodeQL via API
         env:


### PR DESCRIPTION
Move interpolações do github context para variáveis de ambiente no bloco env: do step, evitando injeção de código via nomes de branch maliciosos (Semgrep: run-shell-injection)