### PR TITLE
feat: add prod CI/CD pipeline and k8s manifests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,200 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+env:
+  NODE_VERSION: "20"
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  # ─── FRONT-END ───────────────────────────────────────
+  frontend-ci:
+    name: "FrontEnd: Lint + Build"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontEnd
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontEnd/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+
+  # ─── BACK-END ────────────────────────────────────────
+  backend-ci:
+    name: "BackEnd: TypeCheck"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backEnd
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: backEnd/package-lock.json
+
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  # ─── DOCKER BUILD (DEV) ─────────────────────────────
+  docker-build-dev:
+    name: "Docker: Build & Push (dev)"
+    needs: [frontend-ci, backend-ci]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    outputs:
+      backend_tag: ${{ steps.meta.outputs.backend_tag }}
+      frontend_tag: ${{ steps.meta.outputs.frontend_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BAYAREA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - id: meta
+        run: |
+          REG=${{ steps.ecr-login.outputs.registry }}
+          TAG=${GITHUB_SHA::7}
+          echo "backend_tag=${REG}/bayarea-prontuario-backend:dev-${TAG}" >> "$GITHUB_OUTPUT"
+          echo "frontend_tag=${REG}/bayarea-prontuario-frontend:dev-${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./backEnd
+          file: ./backEnd/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.backend_tag }}
+            ${{ steps.ecr-login.outputs.registry }}/bayarea-prontuario-backend:dev
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./frontEnd
+          file: ./frontEnd/Dockerfile.prod
+          push: true
+          build-args: |
+            VITE_API_URL=/prontuario-dev/api
+            VITE_BASE=/prontuario-dev/
+          tags: |
+            ${{ steps.meta.outputs.frontend_tag }}
+            ${{ steps.ecr-login.outputs.registry }}/bayarea-prontuario-frontend:dev
+
+  # ─── DEPLOY (DEV) ──────────────────────────────────
+  deploy-dev:
+    name: "Deploy to EKS (dev)"
+    needs: docker-build-dev
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BAYAREA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: |
+          aws eks update-kubeconfig --name ${{ vars.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+          kubectl set image deployment/bayarea-prontuario-backend-dev \
+            backend=${{ needs.docker-build-dev.outputs.backend_tag }} \
+            -n bayarea-web
+          kubectl set image deployment/bayarea-prontuario-frontend-dev \
+            frontend=${{ needs.docker-build-dev.outputs.frontend_tag }} \
+            -n bayarea-web
+          kubectl rollout status deployment/bayarea-prontuario-backend-dev -n bayarea-web --timeout=300s
+          kubectl rollout status deployment/bayarea-prontuario-frontend-dev -n bayarea-web --timeout=300s
+
+  # ─── DOCKER BUILD (PROD) ────────────────────────────
+  docker-build-prod:
+    name: "Docker: Build & Push (prod)"
+    needs: [frontend-ci, backend-ci]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      backend_tag: ${{ steps.meta.outputs.backend_tag }}
+      frontend_tag: ${{ steps.meta.outputs.frontend_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BAYAREA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - id: meta
+        run: |
+          REG=${{ steps.ecr-login.outputs.registry }}
+          TAG=${GITHUB_SHA::7}
+          echo "backend_tag=${REG}/bayarea-backend:${TAG}" >> "$GITHUB_OUTPUT"
+          echo "frontend_tag=${REG}/bayarea-frontend:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./backEnd
+          file: ./backEnd/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.backend_tag }}
+            ${{ steps.ecr-login.outputs.registry }}/bayarea-backend:latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./frontEnd
+          file: ./frontEnd/Dockerfile.prod
+          push: true
+          build-args: |
+            VITE_API_URL=/prontuario/api
+            VITE_BASE=/prontuario/
+          tags: |
+            ${{ steps.meta.outputs.frontend_tag }}
+            ${{ steps.ecr-login.outputs.registry }}/bayarea-frontend:latest
+
+  # ─── DEPLOY (PROD) ─────────────────────────────────
+  deploy-prod:
+    name: "Deploy to EKS (prod)"
+    needs: docker-build-prod
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BAYAREA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: |
+          aws eks update-kubeconfig --name ${{ vars.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+          kubectl apply -f k8s/prod/
+          kubectl set image deployment/bayarea-prontuario-backend \
+            backend=${{ needs.docker-build-prod.outputs.backend_tag }} \
+            -n bayarea-web
+          kubectl set image deployment/bayarea-prontuario-frontend \
+            frontend=${{ needs.docker-build-prod.outputs.frontend_tag }} \
+            -n bayarea-web
+          kubectl rollout status deployment/bayarea-prontuario-backend -n bayarea-web --timeout=300s
+          kubectl rollout status deployment/bayarea-prontuario-frontend -n bayarea-web --timeout=300s

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,18 +4,107 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches: [ "main", "develop" ]
+  workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
+permissions: read-all
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+
+  # =========================================
+  # CODEQL (SAST AVANÇADO)
+  # =========================================
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+ 
+    permissions:
+      contents: read
+      security-events: write
+ 
+    timeout-minutes: 30
+ 
+    strategy:
+      matrix:
+        language: [ 'javascript' ]
+ 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+ 
+      - name: Inicializar CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+ 
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+ 
+      - name: Rodar CodeQL
+        uses: github/codeql-action/analyze@v4
+        with:
+          output: codeql-results
+
+      - name: Checar severidade no SARIF do CodeQL
+        run: |
+          SARIF_FILE=$(find codeql-results -name "*.sarif" | head -1)
+
+          if [ -z "$SARIF_FILE" ]; then
+            echo "⚠️ Nenhum arquivo SARIF encontrado"
+            exit 1
+          fi
+
+          COUNT=$(jq '
+            .runs[] as $run |
+            $run.results[] |
+            . as $result |
+            ($run.tool.extensions[]?.rules[]? |
+              select(.id == $result.ruleId) |
+              .properties["security-severity"] // 0 | tonumber
+            ) |
+            select(. >= 7.0)
+          ' "$SARIF_FILE" | jq -s 'length')
+
+          echo "⚠️ Alertas High/Critical encontrados: $COUNT"
+
+          if [ "$COUNT" -gt "0" ]; then
+            echo "❌ CodeQL encontrou $COUNT vulnerabilidade(s) High/Critical"
+            jq -r '
+              .runs[] as $run |
+              $run.results[] |
+              . as $result |
+              ($run.tool.extensions[]?.rules[]? |
+                select(.id == $result.ruleId)
+              ) as $rule |
+              "\($rule.properties["security-severity"]) | \($result.ruleId) | \($result.message.text)"
+            ' "$SARIF_FILE"
+            exit 1
+          fi
+
+          echo "✅ Nenhuma vulnerabilidade High/Critical encontrada"
+
+  # =========================================
+  # SAST + SONAR + SEMGREP
+  # =========================================
   security:
     name: SAST + SonarQube
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write
+
+    timeout-minutes: 30
+
+    needs: codeql
+    if: always()
+
     steps:
+
       # ------------------------
       # CHECKOUT
       # ------------------------
@@ -31,6 +120,22 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Cache node_modules (backEnd)
+        uses: actions/cache@v4
+        with:
+          path: ./backEnd/node_modules
+          key: ${{ runner.os }}-back-${{ hashFiles('backEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-back-
+
+      - name: Cache node_modules (frontEnd)
+        uses: actions/cache@v4
+        with:
+          path: ./frontEnd/node_modules
+          key: ${{ runner.os }}-front-${{ hashFiles('frontEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-front-
+
       # ------------------------
       # INSTALAR DEPENDÊNCIAS
       # ------------------------
@@ -43,9 +148,8 @@ jobs:
         run: npm install
 
       # ------------------------
-      # TESTES (BACKEND)
+      # TESTES
       # ------------------------
-      # ⚠️ Temporário
       - name: Rodar testes (backEnd)
         working-directory: ./backEnd
         run: npm test || true
@@ -59,7 +163,23 @@ jobs:
       - name: Rodar Semgrep
         id: semgrep
         continue-on-error: true
-        run: semgrep scan --config=p/owasp-top-ten --error
+        run: semgrep scan --config=p/owasp-top-ten --sarif --output=semgrep.sarif --error
+
+      - name: Registrar resultado do Semgrep
+        if: always()
+        run: |
+          if [ "${{ steps.semgrep.outcome }}" = "failure" ]; then
+            echo "SEMGREP_FAILED=true" >> $GITHUB_ENV
+          else
+            echo "SEMGREP_FAILED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
 
       # ------------------------
       # SONARQUBE
@@ -67,9 +187,10 @@ jobs:
       - name: SonarQube Scan
         id: sonar
         continue-on-error: true
-        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
+        uses: SonarSource/sonarqube-scan-action@v2
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
         with:
           args: >
             -Dsonar.projectKey=fabrica-bayarea_Prontuario
@@ -81,13 +202,26 @@ jobs:
       # SECURITY GATE (FINAL)
       # ------------------------
       - name: Security Gate
+        if: always()
         run: |
-          echo "Semgrep result: ${{ steps.semgrep.outcome }}"
+          echo "Semgrep falhou: $SEMGREP_FAILED"
           echo "Sonar result: ${{ steps.sonar.outcome }}"
 
-          if [ "${{ steps.semgrep.outcome }}" != "success" ] || [ "${{ steps.sonar.outcome }}" != "success" ]; then
-            echo "❌ Falha de segurança detectada"
+          FAILED=0
+
+          if [ "$SEMGREP_FAILED" = "true" ]; then
+            echo "❌ Semgrep encontrou vulnerabilidades"
+            FAILED=1
+          fi
+
+          if [ "${{ steps.sonar.outcome }}" != "success" ]; then
+            echo "❌ SonarQube falhou"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" = "1" ]; then
+            echo "❌ Falha de segurança detectada — pipeline bloqueada"
             exit 1
           fi
 
-          echo "✅ Pipeline seguro"
+          echo "✅ Semgrep e SonarQube sem vulnerabilidades"

--- a/backEnd/Dockerfile.prod
+++ b/backEnd/Dockerfile.prod
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npx tsc
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 3001
+CMD ["node", "dist/server.js"]

--- a/frontEnd/Dockerfile.prod
+++ b/frontEnd/Dockerfile.prod
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ARG VITE_API_URL=/prontuario/api
+ARG VITE_BASE=/prontuario/
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontEnd/nginx.conf
+++ b/frontEnd/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/k8s/prod/backend.yaml
+++ b/k8s/prod/backend.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bayarea-prontuario-backend
+  namespace: bayarea-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bayarea-prontuario-backend
+  template:
+    metadata:
+      labels:
+        app: bayarea-prontuario-backend
+    spec:
+      containers:
+        - name: backend
+          image: 248189947068.dkr.ecr.us-east-1.amazonaws.com/bayarea-backend:latest
+          ports:
+            - containerPort: 3001
+          env:
+            - name: PORT
+              value: "3001"
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: rds-prontuario
+                  key: DB_HOST
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: rds-prontuario
+                  key: DB_PORT
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: rds-prontuario
+                  key: DB_NAME
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rds-prontuario
+                  key: DB_USER
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rds-prontuario
+                  key: DB_PASSWORD
+            - name: DB_SSL
+              value: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayarea-prontuario-backend
+  namespace: bayarea-web
+spec:
+  selector:
+    app: bayarea-prontuario-backend
+  ports:
+    - port: 3001
+      targetPort: 3001

--- a/k8s/prod/cicd-rbac.yaml
+++ b/k8s/prod/cicd-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cicd-deployer
+  namespace: bayarea-web
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["services", "configmaps", "secrets"]
+    verbs: ["get", "list", "create", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cicd-deployer-binding
+  namespace: bayarea-web
+subjects:
+  - kind: Group
+    name: cicd-deployer
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: cicd-deployer
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/prod/frontend.yaml
+++ b/k8s/prod/frontend.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bayarea-prontuario-frontend
+  namespace: bayarea-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bayarea-prontuario-frontend
+  template:
+    metadata:
+      labels:
+        app: bayarea-prontuario-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: 248189947068.dkr.ecr.us-east-1.amazonaws.com/bayarea-frontend:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayarea-prontuario-frontend
+  namespace: bayarea-web
+spec:
+  selector:
+    app: bayarea-prontuario-frontend
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
- Production Dockerfiles for backend and frontend
- K8s deployment manifests for bayarea-web namespace (2 replicas each)
- CI/CD pipeline triggered on push to main → builds to bayarea-backend/bayarea-frontend ECR → deploys to EKS
- Updated security.yml from develop